### PR TITLE
[FEAT] 3차 세미나 과제

### DIFF
--- a/second/build.gradle
+++ b/second/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'io.rest-assured:rest-assured'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/second/src/main/java/org/sopt/practice/common/config/JpaAuditingConfig.java
+++ b/second/src/main/java/org/sopt/practice/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package org.sopt.practice.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/second/src/main/java/org/sopt/practice/common/dto/ErrorResponse.java
+++ b/second/src/main/java/org/sopt/practice/common/dto/ErrorResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.practice.common.dto;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record ErrorResponse(
+        boolean success,
+        @NonNull String message
+) {
+
+    public static ErrorResponse of(String message) {
+        return ErrorResponse.builder()
+                .success(false)
+                .message(message)
+                .build();
+    }
+}

--- a/second/src/main/java/org/sopt/practice/common/dto/SuccessResponse.java
+++ b/second/src/main/java/org/sopt/practice/common/dto/SuccessResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.practice.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.NonNull;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record SuccessResponse(
+        boolean success,
+        @NonNull String message,
+        @JsonInclude(value = NON_NULL) Object data
+) {
+
+    public static SuccessResponse of(String message, Object data) {
+        return SuccessResponse.builder()
+                .success(true)
+                .message(message)
+                .data(data)
+                .build();
+    }
+
+    public static SuccessResponse of(String message) {
+        return SuccessResponse.builder()
+                .success(true)
+                .message(message)
+                .build();
+    }
+}

--- a/second/src/main/java/org/sopt/practice/common/handler/ErrorHandler.java
+++ b/second/src/main/java/org/sopt/practice/common/handler/ErrorHandler.java
@@ -1,32 +1,45 @@
 package org.sopt.practice.common.handler;
 
 import lombok.val;
-import org.sopt.practice.common.dto.Response;
+import org.sopt.practice.common.dto.ErrorResponse;
 import org.sopt.practice.exception.BlogException;
 import org.sopt.practice.exception.MemberException;
+import org.sopt.practice.exception.PostingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.Objects;
+
 @RestControllerAdvice
 public class ErrorHandler {
 
     @ExceptionHandler(MemberException.class)
-    public ResponseEntity<Response> memberException(MemberException exception) {
+    public ResponseEntity<ErrorResponse> memberException(MemberException exception) {
         val errorMessage = exception.getErrorMessage();
-        return ResponseEntity.status(errorMessage.getHttpStatus()).body(Response.fail(errorMessage.getMessage()));
+        return ResponseEntity.status(errorMessage.getHttpStatus()).body(ErrorResponse.of(errorMessage.getMessage()));
     }
 
     @ExceptionHandler(BlogException.class)
-    public ResponseEntity<Response> blogException(BlogException exception) {
+    public ResponseEntity<ErrorResponse> blogException(BlogException exception) {
         val errorMessage = exception.getErrorMessage();
-        return ResponseEntity.status(errorMessage.getHttpStatus()).body(Response.fail(errorMessage.getMessage()));
+        return ResponseEntity.status(errorMessage.getHttpStatus()).body(ErrorResponse.of(errorMessage.getMessage()));
+    }
+
+    @ExceptionHandler(PostingException.class)
+    public ResponseEntity<ErrorResponse> postingException(PostingException exception) {
+        val errorMessage = exception.getErrorMessage();
+        return ResponseEntity.status(errorMessage.getHttpStatus()).body(ErrorResponse.of(errorMessage.getMessage()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Response> validException(MethodArgumentNotValidException exception) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.fail("다시."));
+    public ResponseEntity<ErrorResponse> validException(MethodArgumentNotValidException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(getErrorMessage(exception)));
+    }
+
+    private String getErrorMessage(MethodArgumentNotValidException exception) {
+        return Objects.requireNonNull(exception.getBindingResult().getFieldError()).getDefaultMessage();
     }
 }

--- a/second/src/main/java/org/sopt/practice/common/handler/ErrorHandler.java
+++ b/second/src/main/java/org/sopt/practice/common/handler/ErrorHandler.java
@@ -2,8 +2,11 @@ package org.sopt.practice.common.handler;
 
 import lombok.val;
 import org.sopt.practice.common.dto.Response;
+import org.sopt.practice.exception.BlogException;
 import org.sopt.practice.exception.MemberException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -14,5 +17,16 @@ public class ErrorHandler {
     public ResponseEntity<Response> memberException(MemberException exception) {
         val errorMessage = exception.getErrorMessage();
         return ResponseEntity.status(errorMessage.getHttpStatus()).body(Response.fail(errorMessage.getMessage()));
+    }
+
+    @ExceptionHandler(BlogException.class)
+    public ResponseEntity<Response> blogException(BlogException exception) {
+        val errorMessage = exception.getErrorMessage();
+        return ResponseEntity.status(errorMessage.getHttpStatus()).body(Response.fail(errorMessage.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Response> validException(MethodArgumentNotValidException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.fail("다시."));
     }
 }

--- a/second/src/main/java/org/sopt/practice/common/message/ErrorMessage.java
+++ b/second/src/main/java/org/sopt/practice/common/message/ErrorMessage.java
@@ -1,9 +1,10 @@
-package org.sopt.practice.message;
+package org.sopt.practice.common.message;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
@@ -12,6 +13,12 @@ public enum ErrorMessage {
 
     /* 404 NOT_FOUND : 자원을 찾을 수 없음 */
     INVALID_MEMBER(NOT_FOUND, "유효하지 않은 회원입니다."),
+    INVALID_BLOG(NOT_FOUND, "유효하지 않은 블로그입니다."),
+
+
+    /* 409 CONFLICT : 중복된 자원 */
+    EXIST_MEMBER(CONFLICT, "멤버가 이미 존재하는 게시물입니다."),
+    EXIST_BLOG(CONFLICT, "게시물이 이미 존재하는 멤버입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/second/src/main/java/org/sopt/practice/common/message/ErrorMessage.java
+++ b/second/src/main/java/org/sopt/practice/common/message/ErrorMessage.java
@@ -4,16 +4,22 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
 
+    /* 400 BAD_REQUEST : 잘못된 요청 */
+    NOT_MATCH_BLOG_POSTING(BAD_REQUEST, "블로그의 게시글이 아닙니다."),
+
+    /* 403 FORBIDDEN : 권한 없음 */
+    NOT_MATCH_MEMBER_BLOG(FORBIDDEN, "멤버의 블로그가 아닙니다."),
+
     /* 404 NOT_FOUND : 자원을 찾을 수 없음 */
     INVALID_MEMBER(NOT_FOUND, "유효하지 않은 회원입니다."),
     INVALID_BLOG(NOT_FOUND, "유효하지 않은 블로그입니다."),
+    INVALID_POSTING(NOT_FOUND, "유효하지 않은 게시글입니다."),
 
 
     /* 409 CONFLICT : 중복된 자원 */

--- a/second/src/main/java/org/sopt/practice/common/message/SuccessMessage.java
+++ b/second/src/main/java/org/sopt/practice/common/message/SuccessMessage.java
@@ -11,8 +11,12 @@ public enum SuccessMessage {
     SUCCESS_GET_MEMBER("멤버 조회 성공"),
     SUCCESS_DELETE_MEMBER("멤버 삭제 성공"),
     SUCCESS_GET_MEMBER_LIST("멤버 리스트 조회 성공"),
+
     SUCCESS_CREATE_BLOG("블로그 생성 성공"),
     SUCCESS_UPDATE_TITLE("블로그 제목 수정 성공"),
+
+    SUCCESS_CREATE_POSTING("게시글 생성 성공"),
+    SUCCESS_GET_POSTING("게시글 조회 성공"),
     ;
 
     private final String message;

--- a/second/src/main/java/org/sopt/practice/common/message/SuccessMessage.java
+++ b/second/src/main/java/org/sopt/practice/common/message/SuccessMessage.java
@@ -1,4 +1,4 @@
-package org.sopt.practice.message;
+package org.sopt.practice.common.message;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +11,8 @@ public enum SuccessMessage {
     SUCCESS_GET_MEMBER("멤버 조회 성공"),
     SUCCESS_DELETE_MEMBER("멤버 삭제 성공"),
     SUCCESS_GET_MEMBER_LIST("멤버 리스트 조회 성공"),
+    SUCCESS_CREATE_BLOG("블로그 생성 성공"),
+    SUCCESS_UPDATE_TITLE("블로그 제목 수정 성공"),
     ;
 
     private final String message;

--- a/second/src/main/java/org/sopt/practice/controller/BlogController.java
+++ b/second/src/main/java/org/sopt/practice/controller/BlogController.java
@@ -1,0 +1,48 @@
+package org.sopt.practice.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.practice.common.dto.Response;
+import org.sopt.practice.dto.request.BlogCreationRequest;
+import org.sopt.practice.dto.request.BlogTitleUpdateRequest;
+import org.sopt.practice.service.BlogService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+import static org.sopt.practice.common.dto.Response.*;
+import static org.sopt.practice.common.message.SuccessMessage.SUCCESS_CREATE_BLOG;
+import static org.sopt.practice.common.message.SuccessMessage.SUCCESS_UPDATE_TITLE;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/blogs")
+public class BlogController {
+
+    private final BlogService blogService;
+
+    @PostMapping
+    public ResponseEntity<Response> createBlog(@RequestHeader Long memberId, @RequestBody BlogCreationRequest request) {
+        val response = blogService.createBlog(memberId, request);
+        return ResponseEntity.created(getURI())
+                .header("Blog-Id", response)
+                .body(success(SUCCESS_CREATE_BLOG.getMessage()));
+    }
+
+    @PatchMapping("/{blogId}/title")
+    public ResponseEntity<Response> updateTitle(@PathVariable Long blogId, @Valid @RequestBody BlogTitleUpdateRequest request) {
+        blogService.updateTitle(blogId, request);
+        return ResponseEntity.ok(success(SUCCESS_UPDATE_TITLE.getMessage()));
+    }
+
+    private URI getURI() {
+        return ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/")
+                .buildAndExpand()
+                .toUri();
+    }
+}

--- a/second/src/main/java/org/sopt/practice/controller/BlogController.java
+++ b/second/src/main/java/org/sopt/practice/controller/BlogController.java
@@ -3,7 +3,7 @@ package org.sopt.practice.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.sopt.practice.common.dto.Response;
+import org.sopt.practice.common.dto.SuccessResponse;
 import org.sopt.practice.dto.request.BlogCreationRequest;
 import org.sopt.practice.dto.request.BlogTitleUpdateRequest;
 import org.sopt.practice.service.BlogService;
@@ -13,7 +13,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 
-import static org.sopt.practice.common.dto.Response.*;
+import static org.sopt.practice.common.dto.SuccessResponse.*;
 import static org.sopt.practice.common.message.SuccessMessage.SUCCESS_CREATE_BLOG;
 import static org.sopt.practice.common.message.SuccessMessage.SUCCESS_UPDATE_TITLE;
 
@@ -25,17 +25,17 @@ public class BlogController {
     private final BlogService blogService;
 
     @PostMapping
-    public ResponseEntity<Response> createBlog(@RequestHeader Long memberId, @RequestBody BlogCreationRequest request) {
+    public ResponseEntity<SuccessResponse> createBlog(@RequestHeader Long memberId, @Valid @RequestBody BlogCreationRequest request) {
         val response = blogService.createBlog(memberId, request);
         return ResponseEntity.created(getURI())
                 .header("Blog-Id", response)
-                .body(success(SUCCESS_CREATE_BLOG.getMessage()));
+                .body(of(SUCCESS_CREATE_BLOG.getMessage()));
     }
 
     @PatchMapping("/{blogId}/title")
-    public ResponseEntity<Response> updateTitle(@PathVariable Long blogId, @Valid @RequestBody BlogTitleUpdateRequest request) {
+    public ResponseEntity<SuccessResponse> updateTitle(@PathVariable Long blogId, @Valid @RequestBody BlogTitleUpdateRequest request) {
         blogService.updateTitle(blogId, request);
-        return ResponseEntity.ok(success(SUCCESS_UPDATE_TITLE.getMessage()));
+        return ResponseEntity.ok(of(SUCCESS_UPDATE_TITLE.getMessage()));
     }
 
     private URI getURI() {

--- a/second/src/main/java/org/sopt/practice/controller/MemberController.java
+++ b/second/src/main/java/org/sopt/practice/controller/MemberController.java
@@ -1,8 +1,9 @@
 package org.sopt.practice.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
-import org.sopt.practice.common.dto.Response;
+import org.sopt.practice.common.dto.SuccessResponse;
 import org.sopt.practice.dto.request.MemberCreationRequest;
 import org.sopt.practice.service.MemberService;
 import org.springframework.http.ResponseEntity;
@@ -11,7 +12,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 
-import static org.sopt.practice.common.dto.Response.*;
+import static org.sopt.practice.common.dto.SuccessResponse.*;
 import static org.sopt.practice.common.message.SuccessMessage.*;
 
 @RestController
@@ -22,28 +23,28 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping
-    public ResponseEntity<Response> createMember(@RequestBody MemberCreationRequest request) {
+    public ResponseEntity<SuccessResponse> createMember(@Valid @RequestBody MemberCreationRequest request) {
         val response = memberService.createMember(request);
         return ResponseEntity.created(getURI())
-                .body(success(SUCCESS_CREATE_MEMBER.getMessage(), response));
+                .body(of(SUCCESS_CREATE_MEMBER.getMessage(), response));
     }
 
     @GetMapping("/{memberId}")
-    public ResponseEntity<Response> getMember(@PathVariable Long memberId) {
+    public ResponseEntity<SuccessResponse> getMember(@PathVariable Long memberId) {
         val response = memberService.getMember(memberId);
-        return ResponseEntity.ok(success(SUCCESS_GET_MEMBER.getMessage(), response));
+        return ResponseEntity.ok(of(SUCCESS_GET_MEMBER.getMessage(), response));
     }
 
     @DeleteMapping("/{memberId}")
-    public ResponseEntity<Response> deleteMember(@PathVariable Long memberId) {
+    public ResponseEntity<SuccessResponse> deleteMember(@PathVariable Long memberId) {
         memberService.deleteMember(memberId);
-        return ResponseEntity.ok(success(SUCCESS_DELETE_MEMBER.getMessage()));
+        return ResponseEntity.ok(of(SUCCESS_DELETE_MEMBER.getMessage()));
     }
 
     @GetMapping
-    public ResponseEntity<Response> getMembers() {
+    public ResponseEntity<SuccessResponse> getMembers() {
         val response = memberService.getMembers();
-        return ResponseEntity.ok(success(SUCCESS_GET_MEMBER_LIST.getMessage(), response));
+        return ResponseEntity.ok(of(SUCCESS_GET_MEMBER_LIST.getMessage(), response));
     }
 
     private URI getURI() {

--- a/second/src/main/java/org/sopt/practice/controller/MemberController.java
+++ b/second/src/main/java/org/sopt/practice/controller/MemberController.java
@@ -12,7 +12,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.net.URI;
 
 import static org.sopt.practice.common.dto.Response.*;
-import static org.sopt.practice.message.SuccessMessage.*;
+import static org.sopt.practice.common.message.SuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/second/src/main/java/org/sopt/practice/controller/PostingController.java
+++ b/second/src/main/java/org/sopt/practice/controller/PostingController.java
@@ -1,0 +1,51 @@
+package org.sopt.practice.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.practice.common.dto.SuccessResponse;
+import org.sopt.practice.dto.request.PostingCreationRequest;
+import org.sopt.practice.service.PostingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+import static org.sopt.practice.common.dto.SuccessResponse.*;
+import static org.sopt.practice.common.message.SuccessMessage.SUCCESS_CREATE_POSTING;
+import static org.sopt.practice.common.message.SuccessMessage.SUCCESS_GET_POSTING;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1")
+public class PostingController {
+
+    private final PostingService postingService;
+
+    @PostMapping("/blogs/{blogId}/postings")
+    public ResponseEntity<SuccessResponse> createPosting(
+            @RequestHeader Long memberId,
+            @PathVariable Long blogId,
+            @Valid @RequestBody PostingCreationRequest request
+    ) {
+        val response = postingService.createPosting(memberId, blogId, request);
+        return ResponseEntity.created(getURI())
+                .header("Post-Id", response)
+                .body(of(SUCCESS_CREATE_POSTING.getMessage()));
+    }
+
+    @GetMapping("/blogs/{blogId}/postings/{postingId}")
+    public ResponseEntity<SuccessResponse> getPosting(@PathVariable Long blogId, @PathVariable Long postingId) {
+        val response = postingService.getPosting(blogId, postingId);
+        return ResponseEntity.ok(of(SUCCESS_GET_POSTING.getMessage(), response));
+    }
+
+    private URI getURI() {
+        return ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/")
+                .buildAndExpand()
+                .toUri();
+    }
+}

--- a/second/src/main/java/org/sopt/practice/domain/BaseTimeEntity.java
+++ b/second/src/main/java/org/sopt/practice/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package org.sopt.practice.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/second/src/main/java/org/sopt/practice/domain/Blog.java
+++ b/second/src/main/java/org/sopt/practice/domain/Blog.java
@@ -1,0 +1,56 @@
+package org.sopt.practice.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.practice.exception.BlogException;
+
+import java.util.Objects;
+
+import static org.sopt.practice.common.message.ErrorMessage.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Blog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 200)
+    private String title;
+
+    private String description;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Builder
+    public Blog(String title, String description, Member member) {
+        this.title = title;
+        this.description = description;
+        this.member = member;
+    }
+
+    public static Blog of(String title, String description, Member member) {
+        return Blog.builder()
+                .title(title)
+                .description(description)
+                .member(member)
+                .build();
+    }
+
+    private Member setMember(Member member) {
+        if (Objects.nonNull(this.member)) {
+            throw new BlogException(EXIST_MEMBER);
+        }
+        member.initBlog(this);
+        return member;
+    }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+}

--- a/second/src/main/java/org/sopt/practice/domain/Blog.java
+++ b/second/src/main/java/org/sopt/practice/domain/Blog.java
@@ -4,11 +4,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.sopt.practice.exception.BlogException;
-
-import java.util.Objects;
-
-import static org.sopt.practice.common.message.ErrorMessage.*;
 
 @Entity
 @Getter
@@ -40,14 +35,6 @@ public class Blog extends BaseTimeEntity {
                 .description(description)
                 .member(member)
                 .build();
-    }
-
-    private Member setMember(Member member) {
-        if (Objects.nonNull(this.member)) {
-            throw new BlogException(EXIST_MEMBER);
-        }
-        member.initBlog(this);
-        return member;
     }
 
     public void updateTitle(String title) {

--- a/second/src/main/java/org/sopt/practice/domain/Member.java
+++ b/second/src/main/java/org/sopt/practice/domain/Member.java
@@ -4,11 +4,17 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.practice.exception.BlogException;
+
+import java.util.Objects;
+
+import static org.sopt.practice.common.message.ErrorMessage.EXIST_BLOG;
+import static org.sopt.practice.common.message.ErrorMessage.EXIST_MEMBER;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,6 +26,9 @@ public class Member {
     private Part part;
 
     private int age;
+
+    @OneToOne
+    private Blog blog;
 
     @Builder
     private Member(String name, Part part, int age) {
@@ -34,5 +43,12 @@ public class Member {
                 .part(part)
                 .age(age)
                 .build();
+    }
+
+    public void initBlog(Blog blog) {
+        if (Objects.nonNull(this.blog)) {
+            throw new BlogException(EXIST_BLOG);
+        }
+        this.blog = blog;
     }
 }

--- a/second/src/main/java/org/sopt/practice/domain/Posting.java
+++ b/second/src/main/java/org/sopt/practice/domain/Posting.java
@@ -1,8 +1,11 @@
 package org.sopt.practice.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
 
 @Entity
 @Getter
@@ -17,6 +20,20 @@ public class Posting extends BaseTimeEntity {
 
     private String content;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Blog blog;
+    private long blogId;
+
+    @Builder(access = PRIVATE)
+    public Posting(String title, String content, Blog blog) {
+        this.title = title;
+        this.content = content;
+        this.blogId = blog.getId();
+    }
+
+    public static Posting of(String title, String content, Blog blog) {
+        return Posting.builder()
+                .title(title)
+                .content(content)
+                .blog(blog)
+                .build();
+    }
 }

--- a/second/src/main/java/org/sopt/practice/domain/Posting.java
+++ b/second/src/main/java/org/sopt/practice/domain/Posting.java
@@ -1,0 +1,22 @@
+package org.sopt.practice.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Posting extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Blog blog;
+}

--- a/second/src/main/java/org/sopt/practice/dto/request/BlogCreationRequest.java
+++ b/second/src/main/java/org/sopt/practice/dto/request/BlogCreationRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.practice.dto.request;
+
+public record BlogCreationRequest(
+        String title,
+        String description
+) {
+}

--- a/second/src/main/java/org/sopt/practice/dto/request/BlogTitleUpdateRequest.java
+++ b/second/src/main/java/org/sopt/practice/dto/request/BlogTitleUpdateRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.practice.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record BlogTitleUpdateRequest(
+        @Size(max = 5 , message = "블로그 제목이 최대 글자 수(5자)를 초과했습니다.")
+        String title
+) {
+}

--- a/second/src/main/java/org/sopt/practice/dto/request/BlogTitleUpdateRequest.java
+++ b/second/src/main/java/org/sopt/practice/dto/request/BlogTitleUpdateRequest.java
@@ -1,9 +1,11 @@
 package org.sopt.practice.dto.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
 public record BlogTitleUpdateRequest(
-        @Size(max = 5 , message = "블로그 제목이 최대 글자 수(5자)를 초과했습니다.")
+        @NotEmpty
+        @Size(max = 30, message = "블로그 제목이 최대 글자 수(5자)를 초과했습니다.")
         String title
 ) {
 }

--- a/second/src/main/java/org/sopt/practice/dto/request/MemberCreationRequest.java
+++ b/second/src/main/java/org/sopt/practice/dto/request/MemberCreationRequest.java
@@ -1,11 +1,18 @@
 package org.sopt.practice.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.NonNull;
 import org.sopt.practice.domain.Part;
 
 public record MemberCreationRequest(
-    @NonNull String name,
+    @Size(max = 20, message = "이름이 상당하네요...")
+    @NotBlank String name,
     @NonNull Part part,
-    @NonNull int age
+    @Min(value = 18, message = "잼민이는 가라.")
+    @Max(value = 120, message = "어르신...")
+    int age
 ) {
 }

--- a/second/src/main/java/org/sopt/practice/dto/request/PostingCreationRequest.java
+++ b/second/src/main/java/org/sopt/practice/dto/request/PostingCreationRequest.java
@@ -3,8 +3,8 @@ package org.sopt.practice.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record BlogCreationRequest(
+public record PostingCreationRequest(
         @NotBlank String title,
-        @NotNull String description
+        @NotNull String content
 ) {
 }

--- a/second/src/main/java/org/sopt/practice/dto/response/BlogCreationResponse.java
+++ b/second/src/main/java/org/sopt/practice/dto/response/BlogCreationResponse.java
@@ -1,0 +1,4 @@
+package org.sopt.practice.dto.response;
+
+public record BlogCreationResponse() {
+}

--- a/second/src/main/java/org/sopt/practice/dto/response/BlogCreationResponse.java
+++ b/second/src/main/java/org/sopt/practice/dto/response/BlogCreationResponse.java
@@ -1,4 +1,0 @@
-package org.sopt.practice.dto.response;
-
-public record BlogCreationResponse() {
-}

--- a/second/src/main/java/org/sopt/practice/dto/response/MemberProfileResponse.java
+++ b/second/src/main/java/org/sopt/practice/dto/response/MemberProfileResponse.java
@@ -1,12 +1,13 @@
 package org.sopt.practice.dto.response;
 
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NonNull;
 import org.sopt.practice.domain.Member;
 import org.sopt.practice.domain.Part;
 
-@Builder(access = AccessLevel.PRIVATE)
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
 public record MemberProfileResponse(
         long id,
         @NonNull String name,

--- a/second/src/main/java/org/sopt/practice/dto/response/PostingInfoResponse.java
+++ b/second/src/main/java/org/sopt/practice/dto/response/PostingInfoResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.practice.dto.response;
+
+import lombok.Builder;
+import lombok.NonNull;
+import org.sopt.practice.domain.Posting;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@Builder(access = PRIVATE)
+public record PostingInfoResponse(
+        @NonNull String title,
+        @NonNull String content
+) {
+
+    public static PostingInfoResponse of(Posting posting) {
+        return PostingInfoResponse.builder()
+                .title(posting.getTitle())
+                .content(posting.getContent())
+                .build();
+    }
+}

--- a/second/src/main/java/org/sopt/practice/exception/BlogException.java
+++ b/second/src/main/java/org/sopt/practice/exception/BlogException.java
@@ -4,12 +4,12 @@ import lombok.Getter;
 import org.sopt.practice.common.message.ErrorMessage;
 
 @Getter
-public class MemberException extends RuntimeException {
+public class BlogException extends RuntimeException {
 
     private final ErrorMessage errorMessage;
 
-    public MemberException(ErrorMessage errorMessage) {
-        super("[MemberException] : " + errorMessage.getMessage());
+    public BlogException(ErrorMessage errorMessage) {
+        super("[BlogException] : " + errorMessage.getMessage());
         this.errorMessage = errorMessage;
     }
 }

--- a/second/src/main/java/org/sopt/practice/exception/PostingException.java
+++ b/second/src/main/java/org/sopt/practice/exception/PostingException.java
@@ -1,0 +1,15 @@
+package org.sopt.practice.exception;
+
+import lombok.Getter;
+import org.sopt.practice.common.message.ErrorMessage;
+
+@Getter
+public class PostingException extends RuntimeException {
+
+    private final ErrorMessage errorMessage;
+
+    public PostingException(ErrorMessage errorMessage) {
+        super("[PostingException] : " + errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+}

--- a/second/src/main/java/org/sopt/practice/repository/BlogRepository.java
+++ b/second/src/main/java/org/sopt/practice/repository/BlogRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.practice.repository;
+
+import org.sopt.practice.domain.Blog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogRepository extends JpaRepository<Blog, Long> {
+}

--- a/second/src/main/java/org/sopt/practice/repository/PostingRepository.java
+++ b/second/src/main/java/org/sopt/practice/repository/PostingRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.practice.repository;
+
+import org.sopt.practice.domain.Posting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostingRepository extends JpaRepository<Posting, Long> {
+}

--- a/second/src/main/java/org/sopt/practice/service/BlogService.java
+++ b/second/src/main/java/org/sopt/practice/service/BlogService.java
@@ -6,7 +6,6 @@ import org.sopt.practice.domain.Blog;
 import org.sopt.practice.domain.Member;
 import org.sopt.practice.dto.request.BlogCreationRequest;
 import org.sopt.practice.dto.request.BlogTitleUpdateRequest;
-import org.sopt.practice.dto.response.BlogCreationResponse;
 import org.sopt.practice.exception.BlogException;
 import org.sopt.practice.exception.MemberException;
 import org.sopt.practice.repository.BlogRepository;
@@ -30,7 +29,8 @@ public class BlogService {
         val member = findMember(memberId);
         val blog = generateBlog(request, member);
         saveBlog(blog);
-        return blog.getId().toString();
+        val response = blog.getId().toString();
+        return response;
     }
 
     @Transactional

--- a/second/src/main/java/org/sopt/practice/service/BlogService.java
+++ b/second/src/main/java/org/sopt/practice/service/BlogService.java
@@ -1,0 +1,60 @@
+package org.sopt.practice.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.practice.domain.Blog;
+import org.sopt.practice.domain.Member;
+import org.sopt.practice.dto.request.BlogCreationRequest;
+import org.sopt.practice.dto.request.BlogTitleUpdateRequest;
+import org.sopt.practice.dto.response.BlogCreationResponse;
+import org.sopt.practice.exception.BlogException;
+import org.sopt.practice.exception.MemberException;
+import org.sopt.practice.repository.BlogRepository;
+import org.sopt.practice.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.sopt.practice.common.message.ErrorMessage.INVALID_BLOG;
+import static org.sopt.practice.common.message.ErrorMessage.INVALID_MEMBER;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlogService {
+
+    private final MemberRepository memberRepository;
+    private final BlogRepository blogRepository;
+
+    @Transactional
+    public String createBlog(long memberId, BlogCreationRequest request) {
+        val member = findMember(memberId);
+        val blog = generateBlog(request, member);
+        saveBlog(blog);
+        return blog.getId().toString();
+    }
+
+    @Transactional
+    public void updateTitle(long blogId, BlogTitleUpdateRequest request) {
+        val blog = findBlog(blogId);
+        blog.updateTitle(request.title());
+    }
+
+    private Member findMember(long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(INVALID_MEMBER));
+    }
+
+    private Blog generateBlog(BlogCreationRequest request, Member member) {
+        val blog = Blog.of(request.title(), request.description(), member);
+        return blog;
+    }
+
+    private void saveBlog(Blog blog) {
+        blogRepository.save(blog);
+    }
+
+    private Blog findBlog(long blogId) {
+        return blogRepository.findById(blogId)
+                .orElseThrow(() -> new BlogException(INVALID_BLOG));
+    }
+}

--- a/second/src/main/java/org/sopt/practice/service/MemberService.java
+++ b/second/src/main/java/org/sopt/practice/service/MemberService.java
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.sopt.practice.message.ErrorMessage.INVALID_MEMBER;
+import static org.sopt.practice.common.message.ErrorMessage.INVALID_MEMBER;
 
 @Service
 @RequiredArgsConstructor

--- a/second/src/main/java/org/sopt/practice/service/PostingService.java
+++ b/second/src/main/java/org/sopt/practice/service/PostingService.java
@@ -1,0 +1,4 @@
+package org.sopt.practice.service;
+
+public class PostingService {
+}

--- a/second/src/main/java/org/sopt/practice/service/PostingService.java
+++ b/second/src/main/java/org/sopt/practice/service/PostingService.java
@@ -1,4 +1,83 @@
 package org.sopt.practice.service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.sopt.practice.domain.Blog;
+import org.sopt.practice.domain.Member;
+import org.sopt.practice.domain.Posting;
+import org.sopt.practice.dto.request.PostingCreationRequest;
+import org.sopt.practice.dto.response.PostingInfoResponse;
+import org.sopt.practice.exception.BlogException;
+import org.sopt.practice.exception.MemberException;
+import org.sopt.practice.exception.PostingException;
+import org.sopt.practice.repository.BlogRepository;
+import org.sopt.practice.repository.MemberRepository;
+import org.sopt.practice.repository.PostingRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.sopt.practice.common.message.ErrorMessage.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PostingService {
+
+    private final MemberRepository memberRepository;
+    private final BlogRepository blogRepository;
+    private final PostingRepository postingRepository;
+
+    @Transactional
+    public String createPosting(long memberId, long blogId, PostingCreationRequest request) {
+        val member = findMember(memberId);
+        val blog = findBlog(blogId);
+        checkMemberBlog(member, blog);
+        val posting = generatePosting(blog, request);
+        savePosting(posting);
+        val response = posting.getId().toString();
+        return response;
+    }
+
+    public PostingInfoResponse getPosting(long blogId, long postingId) {
+        val blog = findBlog(blogId);
+        val posting = findPosting(postingId);
+        checkBlogPosting(blog, posting);
+        val response = PostingInfoResponse.of(posting);
+        return response;
+    }
+
+    private Member findMember(long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(INVALID_MEMBER));
+    }
+
+    private Blog findBlog(long blogId) {
+        return blogRepository.findById(blogId)
+                .orElseThrow(() -> new BlogException(INVALID_BLOG));
+    }
+
+    private void checkMemberBlog(Member member, Blog blog) {
+        if (!blog.getMember().equals(member)) {
+            throw new BlogException(NOT_MATCH_MEMBER_BLOG);
+        }
+    }
+
+    private Posting generatePosting(Blog blog, PostingCreationRequest request) {
+        return Posting.of(request.title(), request.content(), blog);
+    }
+
+    private void savePosting(Posting posting) {
+        postingRepository.save(posting);
+    }
+
+    private Posting findPosting(long postingId) {
+        return postingRepository.findById(postingId)
+                .orElseThrow(() -> new PostingException(INVALID_POSTING));
+    }
+
+    private void checkBlogPosting(Blog blog, Posting posting) {
+        if (posting.getBlogId() != blog.getId()) {
+            throw new PostingException(NOT_MATCH_BLOG_POSTING);
+        }
+    }
 }

--- a/second/src/test/java/org/sopt/practice/controller/BlogControllerTest.java
+++ b/second/src/test/java/org/sopt/practice/controller/BlogControllerTest.java
@@ -1,0 +1,60 @@
+package org.sopt.practice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sopt.practice.dto.request.BlogCreationRequest;
+import org.sopt.practice.repository.BlogRepository;
+import org.sopt.practice.repository.MemberRepository;
+import org.sopt.practice.service.BlogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BlogController.class)
+@AutoConfigureMockMvc
+class BlogControllerTest {
+
+    @SpyBean
+    private BlogService blogService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private BlogRepository blogRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Nested
+    class createBlog {
+
+        @Test
+        @DisplayName("존재하지 않는 멤버의 id를 헤더에 입력하면 블로그 생성에 실패한다.")
+        public void createBlogFail() throws Exception {
+            String request = objectMapper.writeValueAsString(new BlogCreationRequest("찬이네 블로그", "찬이네 블로그입니다."));
+
+            mockMvc.perform(
+                            post("/api/v1/blogs")
+                                    .content(request).header("memberId", 2)
+                                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andDo(print());
+        }
+    }
+
+}


### PR DESCRIPTION
## ✨ Related Issue
- close #5  
  <br/>
  
## 🏃‍♂️ API 명세서
https://private-sycamore-e7f.notion.site/SOPT-api-20126101a84449299240b716f7001bb4?pvs=4

## 📝 기능 구현 명세
![image](https://github.com/NOW-SOPT-SERVER/Chan531/assets/81404890/234d32b2-5930-48f3-a08b-abb89ac1c41d)
![image](https://github.com/NOW-SOPT-SERVER/Chan531/assets/81404890/87ea9af8-f584-48a8-85e3-e4cc3555bd21)
- 멤버 생성 api / name 예외

![image](https://github.com/NOW-SOPT-SERVER/Chan531/assets/81404890/5d9cb05f-f523-4aac-9aa0-491a493cafc5)
![image](https://github.com/NOW-SOPT-SERVER/Chan531/assets/81404890/8e3b44df-37e5-4dbc-9f64-36cb80c7b9c5)
- 멤버 생성 api / age 예외

![image](https://github.com/NOW-SOPT-SERVER/Chan531/assets/81404890/11d83b18-4598-4abd-aeef-d66e99d8b39f)
- 블로그 생성 api / title 예

![image](https://github.com/NOW-SOPT-SERVER/Chan531/assets/81404890/42b5e01f-d304-425a-8f55-abe2a46da913)
- 게시글 생성 api

![image](https://github.com/NOW-SOPT-SERVER/Chan531/assets/81404890/e972e2ba-885c-4b92-adc1-5f55f309e83d)
- 게시글 생성 api / member의 블로그가 아닌 경우

![image](https://github.com/NOW-SOPT-SERVER/Chan531/assets/81404890/dfa55f17-caa3-4563-8f93-0ee00ad5e8c0)
- 게시글 조회 api

![image](https://github.com/NOW-SOPT-SERVER/Chan531/assets/81404890/0e2d24a4-9991-4f02-b06c-099860bbdb93)
- 게시글 조회 api / blog의 게시글이 아닌 경우

## 기능 설명
- 그럭저럭 잘 돌아갑니다^^

## 🐥 추가적인 언급 사항
- api 명세서 추가 예정입니다. (5.1 추가 완료)